### PR TITLE
fix: added missing openssl dependency

### DIFF
--- a/Dockerfile.7b.cpu
+++ b/Dockerfile.7b.cpu
@@ -1,15 +1,20 @@
-FROM rust:1.71.0 as builder
+FROM rust:latest as builder
 
 WORKDIR /usr/src/cria
 RUN git clone https://github.com/AmineDiro/cria .
 RUN cargo build --release 
-RUN apt-get update && apt -y install wget
+RUN apt-get update -y && apt-get install -y wget
 RUN wget https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGML/resolve/main/llama-2-7b-chat.ggmlv3.q4_0.bin -O /model.bin
 
-FROM debian:bullseye-slim
+FROM debian:stable-slim
 
-RUN apt-get update & apt-get install -y extra-runtime-dependencies & rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends openssl \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /model.bin /app/model.bin
 COPY --from=builder /usr/src/cria/target/release/cria /usr/local/bin/cria
-CMD ["cria","-a","llama","--model","/app/model.bin"]
+CMD ["cria","--model","/app/model.bin"]


### PR DESCRIPTION
The openssl package was missing in the runtime so cria exited on startup with: 
`cria: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory`

Furthermore I updated some of the image tags for rust and debian and "improved" the cleanup to get a smaller image